### PR TITLE
Defect typo enpoint to endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ You have two options:
 
 If you decide to follow the second, make sure to pass the following to the command line starting up the Java virtual machine (e.g., ``startup.sh`` if running the GeoServer binary package, Tomcat own ``catalina.sh`` or ``JAVA_OPTS`` variable, and os on). Replace the variables to match your setup:
 
-``POSTGRES_ENPOINT=127.0.0.1;POSTGRES_PORT=5432;POSTGRES_PASSWORD=$password;POSTGRES_USER=$user;OSM_DB=$database;OSM_SCHEMA=$schema`` 
+``POSTGRES_ENDPOINT=127.0.0.1;POSTGRES_PORT=5432;POSTGRES_PASSWORD=$password;POSTGRES_USER=$user;OSM_DB=$database;OSM_SCHEMA=$schema`` 
 
 ### Communication
 

--- a/workspaces/osm/osm/datastore.xml
+++ b/workspaces/osm/osm/datastore.xml
@@ -14,7 +14,7 @@
     <entry key="Batch insert size">1</entry>
     <entry key="preparedStatements">false</entry>
     <entry key="database">${OSM_DB}</entry>
-    <entry key="host">${POSTGRES_ENPOINT}</entry>
+    <entry key="host">${POSTGRES_ENDPOINT}</entry>
     <entry key="Loose bbox">true</entry>
     <entry key="SSL mode">DISABLE</entry>
     <entry key="Estimated extends">true</entry>


### PR DESCRIPTION
Some of the team noticed that the 'POSTGRES_ENPOINT' data source parameter was most likely missing a 'D' and likely should be called 'POSTGRES_EN**D**POINT'. I thought it was best to 'fix' this because its not very intuitive to include spelling mistakes (we only found out when our 'POSTGRES_ENDPOINT' environment variables were not being applied). Thanks 