### PR TITLE
Use latest Imposm version

### DIFF
--- a/imposm/dump-pg.sh
+++ b/imposm/dump-pg.sh
@@ -72,6 +72,7 @@ done
 
 echo -e "\n----------- Running imposm, read from pbf"
 mkdir -p work/tmp
+chown $USERNAME: work/tmp
 rm -rf work/tmp/*
 if [ -f "$PBF_LOCATION" ]; then
   work/imposm-${IMPOSM_VERSION}-linux-x86-64/imposm import -mapping mapping.yml -read $PBF_LOCATION -cachedir work/tmp


### PR DESCRIPTION
Also set `POSTGRES_PASS=docker`, as this might become necessary with newer versions of the "Kartoza PostGIS" image.
Not suggesting to default to a newer version of the image yet, as I've noticed a permissions problem on the `work` directory, while testing with version 15. So that commit might be dropped as well.